### PR TITLE
Add conversation pop, retry, save/load, and export commands

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -1,6 +1,7 @@
 use codex_core::protocol::ConversationPathResponseEvent;
 use codex_core::protocol::Event;
 use codex_file_search::FileMatch;
+use std::path::PathBuf;
 
 use crate::history_cell::HistoryCell;
 
@@ -18,6 +19,26 @@ pub(crate) enum AppEvent {
 
     /// Request to exit the application gracefully.
     ExitRequest,
+
+    /// Remove the most recent user turn (and associated agent responses) from context.
+    PopLastTurn,
+
+    /// Remove the most recent agent responses and resend the last user turn.
+    RetryLastTurn,
+
+    /// Export the current conversation transcript to a file.
+    ExportTranscript,
+
+    /// Save the current conversation state to a checkpoint file.
+    SaveCheckpoint,
+
+    /// Present a picker for loading a previously saved checkpoint.
+    OpenLoadSaves,
+
+    /// Load a conversation from a saved checkpoint at the provided path.
+    LoadSavedConversation {
+        path: PathBuf,
+    },
 
     /// Forward an `Op` to the Agent. Using an `AppEvent` for this avoids
     /// bubbling channels through layers of widgets.

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -871,6 +871,21 @@ impl ChatWidget {
                 self.clear_token_usage();
                 self.app_event_tx.send(AppEvent::CodexOp(Op::Compact));
             }
+            SlashCommand::Pop => {
+                self.app_event_tx.send(AppEvent::PopLastTurn);
+            }
+            SlashCommand::Retry => {
+                self.app_event_tx.send(AppEvent::RetryLastTurn);
+            }
+            SlashCommand::Save => {
+                self.app_event_tx.send(AppEvent::SaveCheckpoint);
+            }
+            SlashCommand::Load => {
+                self.app_event_tx.send(AppEvent::OpenLoadSaves);
+            }
+            SlashCommand::Export => {
+                self.app_event_tx.send(AppEvent::ExportTranscript);
+            }
             SlashCommand::Model => {
                 self.open_model_popup();
             }
@@ -1318,6 +1333,17 @@ impl ChatWidget {
             Some("Press Enter to confirm or Esc to go back".to_string()),
             items,
         );
+    }
+
+    pub(crate) fn open_saved_sessions_popup(
+        &mut self,
+        title: String,
+        subtitle: Option<String>,
+        hint: Option<String>,
+        items: Vec<SelectionItem>,
+    ) {
+        self.bottom_pane
+            .show_selection_view(title, subtitle, hint, items);
     }
 
     /// Set the approval policy in the widget's config copy.

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -17,6 +17,11 @@ pub enum SlashCommand {
     New,
     Init,
     Compact,
+    Pop,
+    Retry,
+    Save,
+    Load,
+    Export,
     Diff,
     Mention,
     Status,
@@ -34,6 +39,13 @@ impl SlashCommand {
             SlashCommand::New => "start a new chat during a conversation",
             SlashCommand::Init => "create an AGENTS.md file with instructions for Codex",
             SlashCommand::Compact => "summarize conversation to prevent hitting the context limit",
+            SlashCommand::Pop => "remove the latest user turn and agent replies from context",
+            SlashCommand::Retry => {
+                "drop the latest agent replies and resend the most recent user turn"
+            }
+            SlashCommand::Save => "save the current conversation checkpoint",
+            SlashCommand::Load => "load a saved conversation checkpoint",
+            SlashCommand::Export => "export the current conversation transcript to a file",
             SlashCommand::Quit => "exit Codex",
             SlashCommand::Diff => "show git diff (including untracked files)",
             SlashCommand::Mention => "mention a file",
@@ -59,6 +71,11 @@ impl SlashCommand {
             SlashCommand::New
             | SlashCommand::Init
             | SlashCommand::Compact
+            | SlashCommand::Pop
+            | SlashCommand::Retry
+            | SlashCommand::Save
+            | SlashCommand::Load
+            | SlashCommand::Export
             | SlashCommand::Model
             | SlashCommand::Approvals
             | SlashCommand::Logout => false,


### PR DESCRIPTION
## Summary
- add new slash commands for popping history, retrying, exporting, and managing checkpoints
- implement context history request handling to pop or retry turns, export transcripts, and save/load checkpoints
- surface a load-checkpoint picker in the chat widget for selecting saved sessions

## Testing
- cargo fmt
