### PR TITLE
Add tests for conversation control commands

### DIFF
--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -301,7 +301,7 @@ impl App {
     }
 
     /// Thin wrapper around ConversationManager::fork_conversation.
-    async fn perform_fork(
+    pub(crate) async fn perform_fork(
         &self,
         path: PathBuf,
         drop_count: usize,
@@ -311,7 +311,7 @@ impl App {
     }
 
     /// Install a forked conversation into the ChatWidget and update UI to reflect selection.
-    fn install_forked_conversation(
+    pub(crate) fn install_forked_conversation(
         &mut self,
         tui: &mut tui::Tui,
         cfg: codex_core::config::Config,


### PR DESCRIPTION
## Summary
- Return early after handling conversation history responses and simplify checkpoint directory creation
- Sanitize checkpoint filenames with the conversation ID and expose fork helpers across modules
- Add helper utilities and tests covering pop, retry, save, and export flows

## Testing
- `cargo clippy --tests`
