### PR TITLE
feat: add automatic conversation checkpoints

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -39,6 +39,7 @@ use toml_edit::Table as TomlTable;
 
 const OPENAI_DEFAULT_MODEL: &str = "gpt-5";
 const OPENAI_DEFAULT_REVIEW_MODEL: &str = "gpt-5";
+pub(crate) const DEFAULT_AUTO_CHECKPOINT_KEEP: usize = 5;
 pub const GPT_5_CODEX_MEDIUM_MODEL: &str = "gpt-5-codex";
 
 /// Maximum number of bytes of the documentation that will be embedded. Larger
@@ -139,6 +140,10 @@ pub struct Config {
     /// Directory containing all Codex state (defaults to `~/.codex` but can be
     /// overridden by the `CODEX_HOME` environment variable).
     pub codex_home: PathBuf,
+
+    /// Number of automatic checkpoints to retain. When set to 0, auto
+    /// checkpoints are disabled.
+    pub auto_checkpoint_keep: usize,
 
     /// Settings that govern if and what will be written to `~/.codex/history.jsonl`.
     pub history: History,
@@ -661,6 +666,9 @@ pub struct ConfigToml {
     #[serde(default)]
     pub history: Option<History>,
 
+    /// Number of automatic checkpoints to retain.
+    pub auto_checkpoint_keep: Option<usize>,
+
     /// Optional URI-based file opener. If set, citations to files in the model
     /// output will be hyperlinked using the specified URI scheme.
     pub file_opener: Option<UriBasedFileOpener>,
@@ -1053,6 +1061,9 @@ impl Config {
                 .as_ref()
                 .map(|t| t.notifications.clone())
                 .unwrap_or_default(),
+            auto_checkpoint_keep: cfg
+                .auto_checkpoint_keep
+                .unwrap_or(DEFAULT_AUTO_CHECKPOINT_KEEP),
         };
         Ok(config)
     }
@@ -1616,6 +1627,7 @@ model_verbosity = "high"
                 include_view_image_tool: true,
                 active_profile: Some("o3".to_string()),
                 disable_paste_burst: false,
+                auto_checkpoint_keep: DEFAULT_AUTO_CHECKPOINT_KEEP,
                 tui_notifications: Default::default(),
             },
             o3_profile_config
@@ -1674,6 +1686,7 @@ model_verbosity = "high"
             include_view_image_tool: true,
             active_profile: Some("gpt3".to_string()),
             disable_paste_burst: false,
+            auto_checkpoint_keep: DEFAULT_AUTO_CHECKPOINT_KEEP,
             tui_notifications: Default::default(),
         };
 
@@ -1747,6 +1760,7 @@ model_verbosity = "high"
             include_view_image_tool: true,
             active_profile: Some("zdr".to_string()),
             disable_paste_burst: false,
+            auto_checkpoint_keep: DEFAULT_AUTO_CHECKPOINT_KEEP,
             tui_notifications: Default::default(),
         };
 
@@ -1806,6 +1820,7 @@ model_verbosity = "high"
             include_view_image_tool: true,
             active_profile: Some("gpt5".to_string()),
             disable_paste_burst: false,
+            auto_checkpoint_keep: DEFAULT_AUTO_CHECKPOINT_KEEP,
             tui_notifications: Default::default(),
         };
 

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -335,6 +335,7 @@ impl App {
         // Trim transcript up to the selected user message and re-render it.
         self.trim_transcript_for_backtrack(drop_count);
         self.render_transcript_once(tui);
+        self.clear_auto_checkpoint_queue();
         if !prefill.is_empty() {
             self.chat_widget.set_composer_text(prefill.to_string());
         }

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -32,6 +32,9 @@ pub(crate) enum AppEvent {
     /// Save the current conversation state to a checkpoint file.
     SaveCheckpoint,
 
+    /// Request to create an automatic checkpoint after a completed turn.
+    TriggerAutoCheckpoint,
+
     /// Present a picker for loading a previously saved checkpoint.
     OpenLoadSaves,
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -272,6 +272,7 @@ impl ChatWidget {
         self.maybe_send_next_queued_input();
         // Emit a notification when the turn completes (suppressed if focused).
         self.notify(Notification::AgentTurnComplete);
+        self.app_event_tx.send(AppEvent::TriggerAutoCheckpoint);
     }
 
     pub(crate) fn set_token_info(&mut self, info: Option<TokenUsageInfo>) {

--- a/docs/config.md
+++ b/docs/config.md
@@ -630,6 +630,7 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | `profiles.<name>.*` | various | Profile‑scoped overrides of the same keys. |
 | `history.persistence` | `save-all` \| `none` | History file persistence (default: `save-all`). |
 | `history.max_bytes` | number | Currently ignored (not enforced). |
+| `auto_checkpoint_keep` | number | Automatically retain this many recent checkpoints (default: `5`; set to `0` to disable). |
 | `file_opener` | `vscode` \| `vscode-insiders` \| `windsurf` \| `cursor` \| `none` | URI scheme for clickable citations (default: `vscode`). |
 | `tui` | table | TUI‑specific options. |
 | `tui.notifications` | boolean \| array<string> | Enable desktop notifications in the tui (default: false). |


### PR DESCRIPTION
## Summary
- enable configurable auto checkpoint retention in config and document it
- automatically queue checkpoints after each completed turn and prune old autosaves
- label autosaves when listing checkpoints and cover behavior with tests

## Testing
- cargo test -p codex-tui
- just fix -p codex-tui
