### PR TITLE
Remove truncation limit for AGENTS.md project docs

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -42,10 +42,11 @@ const OPENAI_DEFAULT_REVIEW_MODEL: &str = "gpt-5";
 pub(crate) const DEFAULT_AUTO_CHECKPOINT_KEEP: usize = 5;
 pub const GPT_5_CODEX_MEDIUM_MODEL: &str = "gpt-5-codex";
 
-/// Maximum number of bytes of the documentation that will be embedded. Larger
-/// files are *silently truncated* to this size so we do not take up too much of
-/// the context window.
-pub(crate) const PROJECT_DOC_MAX_BYTES: usize = 32 * 1024; // 32 KiB
+/// Maximum number of bytes of the documentation that will be embedded by
+/// default. We now use an effectively unlimited budget so the entire
+/// `AGENTS.md` contents are included unless the user explicitly overrides this
+/// value (for example, to disable project docs by setting it to zero).
+pub(crate) const PROJECT_DOC_MAX_BYTES: usize = usize::MAX;
 
 pub(crate) const CONFIG_TOML_FILE: &str = "config.toml";
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -576,7 +576,7 @@ This is analogous to `model_context_window`, but for the maximum number of outpu
 
 ## project_doc_max_bytes
 
-Maximum number of bytes to read from an `AGENTS.md` file to include in the instructions sent with the first turn of a session. Defaults to 32 KiB.
+Maximum number of bytes to read from an `AGENTS.md` file to include in the instructions sent with the first turn of a session. Defaults to unlimited (set to `0` to disable project docs entirely or to a smaller value to impose a cap).
 
 ## tui
 
@@ -630,7 +630,7 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | `model_providers.<id>.request_max_retries` | number | Per‑provider HTTP retry count (default: 4). |
 | `model_providers.<id>.stream_max_retries` | number | SSE stream retry count (default: 5). |
 | `model_providers.<id>.stream_idle_timeout_ms` | number | SSE idle timeout (ms) (default: 300000). |
-| `project_doc_max_bytes` | number | Max bytes to read from `AGENTS.md`. |
+| `project_doc_max_bytes` | number | Max bytes to read from `AGENTS.md` (defaults to unlimited; set to `0` to disable). |
 | `profile` | string | Active profile name. |
 | `profiles.<name>.*` | various | Profile‑scoped overrides of the same keys. |
 | `history.persistence` | `save-all` \| `none` | History file persistence (default: `save-all`). |


### PR DESCRIPTION
## Summary
- set the default project documentation budget to unlimited so full AGENTS.md content is included
- refresh project_doc tests to use the unlimited default and cover large files end-to-end
- update the configuration docs to describe the new default behaviour

## Testing
- USER=root cargo test -p codex-core
